### PR TITLE
Redesign favicon with brand colors and Unbounded font

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,4 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" fill="#fafaf8"/>
-  <text x="4" y="24" font-family="system-ui, sans-serif" font-size="20" font-weight="500" fill="#2255cc">L</text>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Unbounded:wght@700&amp;display=swap');
+  </style>
+  <rect width="32" height="32" rx="7" fill="#faf7f2"/>
+  <rect x="4" y="4" width="24" height="24" rx="5" fill="#2B5CE6"/>
+  <text
+    x="16" y="23"
+    font-family="Unbounded, sans-serif"
+    font-weight="700"
+    font-size="11"
+    text-anchor="middle"
+    fill="#faf7f2"
+  >LW</text>
 </svg>


### PR DESCRIPTION
Replaces the minimal plain-text "L" with a polished icon: rounded blue square (accent #2B5CE6) on the site's warm background (#faf7f2), with "LW" initials in the Unbounded display font at 700 weight.