### PR TITLE
Replace outdated speaking links with slides

### DIFF
--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -54,7 +54,7 @@ export const speaking = [
   {
     title: "Progress over Perfection: Your First Steps in Accessibility",
     event: "LibertyJS 2023",
-    url: "https://www.shleewhite.com/progress-over-perfection/#/",
+    url: "https://shleewhite.github.io/progress-over-perfection/",
   },
   {
     title: "Accessibility and Web Components",

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -54,19 +54,16 @@ export const speaking = [
   {
     title: "Progress over Perfection: Your First Steps in Accessibility",
     event: "LibertyJS 2023",
-    url: "https://libertyjs.com/schedule/2023-10-13?sessionId=progressOverPerfectionYourFirstStepsInAccessibility",
-    slides: "https://www.shleewhite.com/progress-over-perfection/#/",
+    url: "https://www.shleewhite.com/progress-over-perfection/#/",
   },
   {
     title: "Accessibility and Web Components",
     event: "A11Y Camp Bay Area 2020",
-    url: "https://www.accessibilitycampbay.org/2020talks.php",
-    slides: "https://docs.google.com/presentation/d/1iRdwHgmQDs2zADAXcMcIXAJazaT05_w7j1Gk6SwBZLc/edit?usp=sharing",
+    url: "https://docs.google.com/presentation/d/1iRdwHgmQDs2zADAXcMcIXAJazaT05_w7j1Gk6SwBZLc/edit?usp=sharing",
   },
   {
     title: "Salesforce for All: Building Accessible Web Components",
     event: "Dreamforce 2019",
-    url: "https://success.salesforce.com/sessions?eventId=a1Q3A000021ea1UUAQ#/session/a2q3A000002BJNf",
   },
 ];
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,10 +34,10 @@ const selectedWork = portfolio.slice(0, 2);
       {speaking.map((talk) => (
         <li class="entry">
           <div class="entry__left">
-            <a href={talk.url} class="entry__title" target="_blank" rel="noopener noreferrer">
-              {talk.title}
-            </a>
-            {talk.slides && <a href={talk.slides} class="entry__slides" target="_blank" rel="noopener noreferrer">Slides ↗</a>}
+            {talk.url
+              ? <a href={talk.url} class="entry__title" target="_blank" rel="noopener noreferrer">{talk.title}</a>
+              : <span class="entry__title entry__title--plain">{talk.title}</span>
+            }
           </div>
           <span class="entry__meta">{talk.event}</span>
         </li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -211,6 +211,7 @@ main {
 .entry__title--plain {
   font-size: 14px;
   color: var(--text-primary);
+  text-decoration: none;
 }
 
 .entry__slides {


### PR DESCRIPTION
## Summary

- Talk titles in the Speaking section now link directly to slide decks instead of outdated event pages
- Talks without slides (Dreamforce 2019) render as plain bold text — no link, no underline
- Removed the separate "Slides ↗" link since the title itself now serves that purpose

## Test plan

- [ ] LibertyJS 2023 title links to the slides deck
- [ ] A11Y Camp Bay Area 2020 title links to Google Slides
- [ ] Dreamforce 2019 title is plain black bold text with no link or underline

🤖 Generated with [Claude Code](https://claude.com/claude-code)